### PR TITLE
Optimization: Shared SKTexture

### DIFF
--- a/Life Saver Shared/LifeNode.swift
+++ b/Life Saver Shared/LifeNode.swift
@@ -8,9 +8,9 @@
 
 import SpriteKit
 
-class LifeNode: SKSpriteNode {
-    let debugLabel: SKLabelNode = SKLabelNode()
+let squareTexture = FileGrabber.shared.getSKTexture(named: "square")
 
+class LifeNode: SKSpriteNode {
     let relativePosition: CGPoint
     var alive: Bool
     var timeInState: Int = 0
@@ -21,15 +21,10 @@ class LifeNode: SKSpriteNode {
         self.relativePosition = relativePosition
         self.alive = alive
         aliveColor = color
-        super.init(texture: FileGrabber.shared.getSKTexture(named: "square"), color: aliveColor, size: size)
+        super.init(texture: squareTexture, color: aliveColor, size: size)
         anchorPoint = CGPoint(x: 0, y: 0)
         colorBlendFactor = 1
         zPosition = 0
-
-        addChild(debugLabel)
-        debugLabel.position = CGPoint(x: size.width / 2, y: size.height / 2)
-        debugLabel.zPosition = 4
-        debugLabel.isHidden = true
     }
 
     required init?(coder _: NSCoder) {


### PR DESCRIPTION
Learned a new thing this week, that you can significantly reduce memory usage and draw performance in SpriteKit by sharing an SKTexture between all similar nodes.

In the case of Life Saver, this means there's only one texture stored in memory. On launch, this results in a 50%+ reduction in memory usage... with the small square setting starting memory usage is ~94 MB. After this optimization, starting memory usage is ~44 MB.

Additionally, per-frame draw count goes from **576** down to **1**. This is pretty amazing.

In this PR I also remove the debug label from nodes, it was using unneeded memory. I could have set a flag to toggle its generation but really it's not needed at this point.